### PR TITLE
Add support to send long SMS by splitting the message into segments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.SMPP</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
     <name>WSO2 Carbon - Mediation Library Connector For SMPP</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/esb/connector/AbstractSendSMS.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/AbstractSendSMS.java
@@ -29,6 +29,8 @@ import org.wso2.carbon.esb.connector.exception.ConfigurationException;
 import java.text.ParseException;
 import java.util.Iterator;
 
+import static org.wso2.carbon.esb.connector.SMPPConstants.SMPP_MAX_CHARACTERS;
+
 /**
  * Parent for SMS Send Operations
  */
@@ -127,5 +129,16 @@ public abstract class AbstractSendSMS extends AbstractConnector implements Conne
     protected void handleSMPPError(String msg, Exception e, MessageContext messageContext) {
         messageContext.setProperty(SMPPConstants.SMPP_ERROR, e.getMessage());
         handleException(msg, e, messageContext);
+    }
+
+    /**
+     * This method will check whether the message length is greater than maximum SMPP character limit.
+     *
+     * @param dto The SMS DTO containing all the message related data
+     * @return true if the message length is greater than maximum SMPP character limit
+     */
+    protected boolean isLongSMS(SMSDTO dto) {
+
+        return dto.getMessage().getBytes().length > SMPP_MAX_CHARACTERS;
     }
 }

--- a/src/main/java/org/wso2/carbon/esb/connector/SMPPConstants.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SMPPConstants.java
@@ -71,6 +71,7 @@ public class SMPPConstants {
     public static final String DESTINATION_ADDRESS_NUMBERING_PLAN= "numberingPlan";
     public static final String DESTINATION_ADDRESS_MOBILE_NUMBER= "mobileNumber";
     public static final String RESULTS = "results";
+    public static final String RESULT = "result";
     public static final String UNSUCCESSFUL_DELIVERIES = "unsuccessfulDeliveries";
     public static final String UNSUCCESSFUL_DELIVERY = "unsuccessfulDelivery";
     public static final int MAXIMUM_DESTINATIONS = 255;

--- a/src/main/java/org/wso2/carbon/esb/connector/SMPPConstants.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SMPPConstants.java
@@ -76,4 +76,13 @@ public class SMPPConstants {
     public static final int MAXIMUM_DESTINATIONS = 255;
     public static final String SMPP_ERROR = "SMPP_ERROR";
     public static final String TIME_FORMAT = "yyyy-MM-dd HH:mm:ss z";
+
+    public static final int SMPP_MAX_CHARACTERS = 153;
+
+    // Length of the rest of the UDH
+    public static final byte UDHIE_HEADER_LENGTH = 0x05;
+    // UDH to indicate a multipart message.
+    public static final byte UDHIE_IDENTIFIER_SAR = 0x00;
+    // Length of the sub header(the rest of the UDH)
+    public static final byte UDHIE_SAR_LENGTH = 0x03;
 }

--- a/src/main/java/org/wso2/carbon/esb/connector/SendSMS.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SendSMS.java
@@ -206,17 +206,6 @@ public class SendSMS extends AbstractSendSMS {
     }
 
     /**
-     * This method will check whether the message length is greater than maximum SMPP character limit.
-     *
-     * @param dto The SMS DTO containing all the message related data
-     * @return true if the message length is greater than maximum SMPP character limit
-     */
-    private boolean isLongSMS(SMSDTO dto) {
-
-        return dto.getMessage().getBytes().length > SMPP_MAX_CHARACTERS;
-    }
-
-    /**
      * Generate the result is used to display the result(messageId) after sending message is complete.
      *
      * @param messageContext The message context that is used in generate result mediation flow.


### PR DESCRIPTION
## Purpose
With this improvement, users can use the User Data Headers approach to send multipart SMS. This is tested in SMPPv3 which has a maximum character limit of 160.

Fixes https://github.com/wso2-extensions/esb-connector-smpp/issues/24

## User stories
Since we need to set the `UDHI Indicator` to the message when sending a long SMS, The user will need to set the EMS Class value to `01000000` in the `SMPP.sendSMS` operation.
