### PR TITLE
Fix concurrent session issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.SMPP</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.6</version>
+    <version>1.0.7</version>
     <name>WSO2 Carbon - Mediation Library Connector For SMPP</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/esb/connector/SMPPConstants.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SMPPConstants.java
@@ -76,6 +76,7 @@ public class SMPPConstants {
     public static final String UNSUCCESSFUL_DELIVERY = "unsuccessfulDelivery";
     public static final int MAXIMUM_DESTINATIONS = 255;
     public static final String SMPP_ERROR = "SMPP_ERROR";
+    public static final int MAX_RETRY_COUNT = 3;
     public static final String TIME_FORMAT = "yyyy-MM-dd HH:mm:ss z";
 
     public static final int SMPP_MAX_CHARACTERS = 153;

--- a/src/main/java/org/wso2/carbon/esb/connector/SMSConfig.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SMSConfig.java
@@ -94,7 +94,7 @@ public class SMSConfig extends AbstractConnector implements Connector {
                         host, port, new BindParameter(BindType.BIND_TX,
                                 systemId, password, systemType,
                                 TypeOfNumber.valueOf(addressTON),
-                                NumberingPlanIndicator.valueOf(addressNPI), null));
+                                NumberingPlanIndicator.valueOf(addressNPI), null), SMPPConstants.MAX_RETRY_COUNT);
                 //Set the user session to message context
                 messageContext.setProperty(SMPPConstants.SMPP_SESSION, session);
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
## Purpose
When initially(no bound connections at this moment) request sends multiple concurrent requests to the SMPP service,  multiple connections(sessions) are created for the SMPP server. But out of these multiple connections created initially, going forward only one session will get used to performing the SMPP operation as we only create and add sessions to the list with a unique key per host
This PR will remove unbound connections, enforce synchronous access for creating new connection
