### PR TITLE
Fix thread hanging issue delayed session creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.SMPP</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <name>WSO2 Carbon - Mediation Library Connector For SMPP</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/esb/connector/operations/SMSConfig.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/operations/SMSConfig.java
@@ -77,6 +77,21 @@ public class SMSConfig extends AbstractConnector implements Connector {
         } else {
             enquireLinkTimer = Integer.parseInt(enquirelinktimer);
         }
+        //Used to set Session Binding Timeout
+        String sessionBindingTimeout = (String) getParameter(messageContext,
+                SMPPConstants.SESSION_BIND_TIMEOUT);
+        long sessionBindingTimeoutValue;
+        if (StringUtils.isEmpty(sessionBindingTimeout)) {
+            //set it to default value
+            sessionBindingTimeoutValue = 60000;
+        } else {
+            try {
+                sessionBindingTimeoutValue = Long.parseLong(sessionBindingTimeout);
+            } catch (NumberFormatException e) {
+                // Set to default value in case of an exception
+                sessionBindingTimeoutValue = 60000;
+            }
+        }
         //Time elapsed between smpp request and the corresponding response
         String transactiontimer = (String) getParameter(messageContext,
                 SMPPConstants.TRANSACTION_TIMER);
@@ -105,12 +120,14 @@ public class SMSConfig extends AbstractConnector implements Connector {
 
         try {
             session = SessionManager.getInstance().getSmppSession(enquireLinkTimer, transactionTimer, host, port,
-                                                                  new BindParameter(BindType.BIND_TX, systemId,
-                                                                                    password, systemType,
-                                                                                    TypeOfNumber.valueOf(addressTON),
-                                                                                    NumberingPlanIndicator.valueOf(
-                                                                                            addressNPI), null),
-                                                                  SMPPConstants.MAX_RETRY_COUNT, sessionName);
+                    new BindParameter(BindType.BIND_TX, systemId,
+                            password, systemType,
+                            TypeOfNumber.valueOf(addressTON),
+                            NumberingPlanIndicator.valueOf(
+                                    addressNPI)
+                            , null),
+                    SMPPConstants.MAX_RETRY_COUNT, sessionName
+                    , sessionBindingTimeoutValue);
             SessionsStore.addSMPPSession(sessionName, session);
             if (log.isDebugEnabled()) {
                 log.debug("Connected and bind to " + host);

--- a/src/main/java/org/wso2/carbon/esb/connector/utils/SMPPConstants.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/utils/SMPPConstants.java
@@ -33,6 +33,7 @@ public class SMPPConstants {
     public static final String ADDRESS_TON = "addressTon";
     public static final String ADDRESS_NPI = "addressNpi";
     public static final String ENQUIRELINK_TIMER = "enquireLinkTimer";
+    public static final String SESSION_BIND_TIMEOUT = "sessionBindTimeout";
     public static final int ENQUIRELINK_TIMER_DEFAULT = 50000;
     public static final String TRANSACTION_TIMER = "transactionTimer";
     public static final int TRANSACTION_TIMER_DEFAULT = 100;

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -24,6 +24,8 @@
     <parameter name="systemId" description="Identifies the user requesting to bind (username)"/>
     <parameter name="password" description="Password to allow access"/>
     <parameter name="enquireLinkTimer" description="used check whether SMSC is connected or not"/>
+    <parameter name="sessionBindTimeout"
+               description="session binding timeout,max time which waits until session to get bind"/>
     <parameter name="transactionTimer"
                description="Time elapsed between smpp request and the corresponding response"/>
     <parameter name="systemType" description="Identifies the system type "/>
@@ -36,6 +38,7 @@
         <property name="systemId" expression="$func:systemId"/>
         <property name="password" expression="$func:password"/>
         <property name="enquireLinkTimer" expression="$func:enquireLinkTimer"/>
+        <property name="sessionBindTimeout" expression="$func:sessionBindTimeout"/>
         <property name="transactionTimer" expression="$func:transactionTimer"/>
         <property name="systemType" expression="$func:systemType"/>
         <property name="addressTon" expression="$func:addressTon"/>

--- a/src/main/resources/uischema/init.json
+++ b/src/main/resources/uischema/init.json
@@ -84,6 +84,17 @@
                 {
                   "type": "attribute",
                   "value": {
+                    "name": "sessionBindTimeout",
+                    "displayName": "Session Binding Timeout",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "session binding timeout,max time to wait for a response after sending a bind request"
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
                     "name": "transactionTimer",
                     "displayName": "Transaction Timer",
                     "inputType": "stringOrExpression",

--- a/src/test/resources/artifacts/ESB/config/proxies/SMPP/smppProxy.xml
+++ b/src/test/resources/artifacts/ESB/config/proxies/SMPP/smppProxy.xml
@@ -51,6 +51,7 @@
             <property name="submitDefaultMsgId" expression="json-eval($.submitDefaultMsgId)"/>
             <property name="validityPeriod" expression="json-eval($.validityPeriod)"/>
             <property name="enquireLinkTimer" expression="json-eval($.enquireLinkTimer)"/>
+            <property name="sessionBindTimeout" expression="json-eval($.sessionBindTimeout)"/>
             <property name="transactionTimer" expression="json-eval($.transactionTimer)"/>
             <SMPP.init>
                 <host>{$ctx:host}</host>
@@ -58,6 +59,7 @@
                 <systemId>{$ctx:systemId}</systemId>
                 <password>{$ctx:password}</password>
                 <enquireLinkTimer>{$ctx:enquireLinkTimer}</enquireLinkTimer>
+                <sessionBindTimeout>{$ctx:sessionBindTimeout}</sessionBindTimeout>
                 <transactionTimer>{$ctx:transactionTimer}</transactionTimer>
                 <systemType>{$ctx:systemType}</systemType>
                 <addressTon>{$ctx:addressTon}</addressTon>


### PR DESCRIPTION


## Purpose
To fix this I used a Java double-locking mechanism with a separate locking object for each key. This is done by maintaining a map of locks, each corresponding to a key so that one session creation is not blocked with other session creation.
Also use the sessionBindingTimeout parameter to avoid the thread waiting for a long time to create a session.

Fixes: https://github.com/wso2/micro-integrator/issues/3050